### PR TITLE
Version Changes

### DIFF
--- a/docs/LV_client/utilities/mono_replace_ego_pose_legacy.md
+++ b/docs/LV_client/utilities/mono_replace_ego_pose_legacy.md
@@ -7,7 +7,7 @@
 ### Description
 
 Replace the pose for the ego vehicle on a specific frame and outputs the JSON corresponding to the frame with the new settings. 
-**This VI proccess frames on a format prior to the release 1.11**
+**This VI processes frames on a format prior to the 1.11 release**
 
 For technical support contact us at <b>support@monodrive.io</b> 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,9 @@ Welcome to monoDrive's documentation.
 
 This home page contains an index with a brief description of the different sections in the documentation. 
 
-The documentation reflects the newest version of the monoDrive Simulation and Scenario Editor v1.11 with Unreal Engine 4.24. We are excited to share our new features including a [Scenario Tool Widget](scenario_editor/scenarios.md) to easily save scenario files to run in Closed Loop mode, updates to the [monoDrive Road Network](scenario_editor/roads.md), enhanced streaming, a new mode-Closed Loop Fixed Time Step, and a new sensor- the monoDrive [occupancy grid sensor]().
+The documentation reflects the newest version of the monoDrive Simulation and Scenario Editor with Unreal Engine 4.24.3. We are excited to share our new features including a [Scenario Tool Widget](scenario_editor/scenarios.md) to easily save scenario files to run in Closed Loop mode, updates to the [monoDrive Road Network](scenario_editor/roads.md), enhanced streaming, a new mode-Closed Loop Fixed Time Step, and a new sensor- the monoDrive [occupancy grid sensor]().
 
-monoDrive's Platform is available now: [Download monoDrive v.1.11](https://www.monodrive.io/register)
+monoDrive's Platform is available now: [Download monoDrive](https://www.monodrive.io/register)
 
 <div class="img_container">
     <img class='md_img' src="./imgs/monodrive_simulator.png"/>

--- a/docs/monoDrive_home/getting_started/Linux.md
+++ b/docs/monoDrive_home/getting_started/Linux.md
@@ -1,6 +1,6 @@
 # Linux
 
-[Download monoDrive v.1.11](https://www.monodrive.io/register)
+[Download monoDrive](https://www.monodrive.io/register)
 
 ## Simulator
 
@@ -12,10 +12,10 @@
 
 1. Extract the archive to a common location like `~/monodrive`.
 1. If downloading for the first time, you will receive an email with a license.txt file attachment. Copy the attached license.txt file to the extracted location `~/monodrive/VehicleAI_Editor/license.txt`.
-1. Clone [Unreal Engine: branch 4.24](https://www.unrealengine.com/en-US/).
-1. Extract the Plugins.zip archive into the 4.24.3 Engine's Plugins directory. e.g. if the UE4.24 branch is cloned at `/usr/local/UE_4.24`, then extract the archive into `/usr/local/UE_4.24/Engine/Plugins`. The resulting directory structure should look as follows:
+1. Clone [Unreal Engine: branch 4.24.3](https://www.unrealengine.com/en-US/).
+1. Extract the Plugins.zip archive into the 4.24.3 Engine's Plugins directory. e.g. if the UE4.24.3 branch is cloned at `/usr/local/UE_4.24.3`, then extract the archive into `/usr/local/UE_4.24.3/Engine/Plugins`. The resulting directory structure should look as follows:
 <pre>
-  /usr/local/UE_4.24/Engine/Plugins/monoDrive
+  /usr/local/UE_4.24.3/Engine/Plugins/monoDrive
     +-- monoDriveRadarSensor
     +-- monoDriveLidarSensor
     +-- ... (other monoDrive plugins)

--- a/docs/monoDrive_home/getting_started/Windows.md
+++ b/docs/monoDrive_home/getting_started/Windows.md
@@ -1,6 +1,6 @@
 # Windows
 
-[Download monoDrive v.1.11](https://www.monodrive.io/register)
+[Download monoDrive](https://www.monodrive.io/register)
 
 ## Simulator
 
@@ -12,17 +12,16 @@
 
 1. Extract the archive to a common location like `C:/monodrive`.
 1. If downloading for the first time, you will receive an email with a license.txt file attachment. Copy the attached license.txt file to the extracted location `C:/monodrive/VehicleAI_Editor/license.txt`.
-1. Install [Unreal Engine 4.24](https://www.unrealengine.com/en-US/).
-1. Extract the Plugins.zip archive into the 4.24.3 Engine's Plugins directory. e.g. if UE4.24 is installed at `c:\Program Files\Unreal\UE_4.24`, then extract the archive into `c:\Program Files\Unreal\UE_4.24\Engine\Plugins`. The resulting directory structure should look as follows:
+1. Install [Unreal Engine 4.24.3](https://www.unrealengine.com/en-US/).
+1. Extract the Plugins.zip archive into the 4.24.3 Engine's Plugins directory. e.g. if UE4.24.3 is installed at `c:\Program Files\Unreal\UE_4.24.3`, then extract the archive into `c:\Program Files\Unreal\UE_4.24.3\Engine\Plugins`. The resulting directory structure should look as follows:
 <pre>
-    c:\Program Files\Unreal\UE_4.24\Engine\Plugins\monoDrive
+    c:\Program Files\Unreal\UE_4.24.3\Engine\Plugins\monoDrive
         +-- monoDriveRadarSensor
         +-- monoDriveLidarSensor
         +-- ... (other monoDrive plugins)
 </pre>         
-Right click on VehicleAI.uproject and select "Generate Project Files".
-Open VehicleAI.uproject. Note that the first time you open the project, UE4 will prompt you about missing modules that need to be rebuilt (VehicleAI and VehicleAIEditor). Select "Yes" to build the modules, then the project will open.
-Refer to monoDrive's Documentation for latest information.
+1. Right click on VehicleAI.uproject and select "Generate Project Files".
+1. Open VehicleAI.uproject. Note that the first time you open the project, UE4 will prompt you about missing modules that need to be rebuilt (VehicleAI and VehicleAIEditor). Select "Yes" to build the modules, then the project will open.
 
 
 ## Scenario Editor: Generating Project Files

--- a/docs/scenario-dashboard.md
+++ b/docs/scenario-dashboard.md
@@ -11,7 +11,7 @@ For a full video demo, see
 
 ## Requirements
 
- - [monoDrive Simulator or Scenario Editor v.1.11](https://www.monodrive.io/register)
+ - [monoDrive Simulator or Scenario Editor](https://www.monodrive.io/register)
     - [Windows Setup](../monoDrive_home/getting_started/Windows)
     - [Linux Setup](../monoDrive_home/getting_started/Linux)
  - [Python Client](../python_client/quick_start)


### PR DESCRIPTION
Removed all instances of monoDrive Simulator Versions (v1.11)
Updated all instances of 4.24 to 4.24.3

Additional update:
Found small grammatical error in one of the LV client pages.