### PR TITLE
Update 1 14 fixes

### DIFF
--- a/docs/monoDrive_home/Camera.md
+++ b/docs/monoDrive_home/Camera.md
@@ -203,8 +203,8 @@ Provides a grayscale camera stream where pixel values represent the semantic cat
     "min_shutter":  0.000500,
     "max_shutter":  0.001400,
     "sensor_size":  9.07,
-   "channels" : "rgba",
-   "annotation": {
+    "channels" : "gray",
+    "annotation": {
       "include_annotation": false,
       "desired_tags": [
         "traffic_sign", "vehicle"

--- a/docs/monoDrive_home/Camera.md
+++ b/docs/monoDrive_home/Camera.md
@@ -302,7 +302,8 @@ represent the distance from the camera in centimeters.
       "debug_draw":false
     },
     "max_distance":50000.0,
-    "channel_depth":1
+    "channels":"gray",
+    "channel_depth":4
  }
 ```
 </div>


### PR DESCRIPTION
### OVERVIEW
Configuration for cameras was wrong.

### CHANGES
Update configuration for the DEPTH camera and SEMANTIC camera.

### TEST
Check results on readthedocs [here](https://monodrive.readthedocs.io/en/update_1_14_fixes/monoDrive_home/Camera/)
